### PR TITLE
ゲーム本編のバランス調整（wave／プレイヤーのショットゲージ周り／敵）

### DIFF
--- a/Assets/Image/Tests/life.png.meta
+++ b/Assets/Image/Tests/life.png.meta
@@ -51,7 +51,7 @@ TextureImporter:
   spriteMeshType: 1
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
-  spritePixelsToUnits: 100
+  spritePixelsToUnits: 500
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1

--- a/Assets/Prefabs/Enemy/HopperEnemy.prefab
+++ b/Assets/Prefabs/Enemy/HopperEnemy.prefab
@@ -165,7 +165,7 @@ BoxCollider2D:
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  m_Size: {x: 3.0277617, y: 2.3533545}
+  m_Size: {x: 2.8, y: 2.4}
   m_EdgeRadius: 0
 --- !u!114 &5254389593530952986
 MonoBehaviour:

--- a/Assets/Prefabs/Enemy/NormalEnemy.prefab
+++ b/Assets/Prefabs/Enemy/NormalEnemy.prefab
@@ -165,7 +165,7 @@ BoxCollider2D:
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  m_Size: {x: 2.9842663, y: 2.8752623}
+  m_Size: {x: 2.8, y: 2.6}
   m_EdgeRadius: 0
 --- !u!114 &5338135221672824041
 MonoBehaviour:

--- a/Assets/Prefabs/Enemy/StrongEnemy.prefab
+++ b/Assets/Prefabs/Enemy/StrongEnemy.prefab
@@ -165,7 +165,7 @@ BoxCollider2D:
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  m_Size: {x: 4.4535475, y: 4.4524646}
+  m_Size: {x: 4.2, y: 4.4}
   m_EdgeRadius: 0
 --- !u!114 &6902443399243036470
 MonoBehaviour:

--- a/Assets/Prefabs/UI/LifeMark.prefab
+++ b/Assets/Prefabs/UI/LifeMark.prefab
@@ -35,7 +35,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 83.6948, y: 82.0062}
+  m_SizeDelta: {x: 48, y: 48}
   m_Pivot: {x: 1, y: 0.5}
 --- !u!222 &1301915701596825478
 CanvasRenderer:

--- a/Assets/ScriptableObjects/Enemy/Enemy Spawner Config.asset
+++ b/Assets/ScriptableObjects/Enemy/Enemy Spawner Config.asset
@@ -22,14 +22,14 @@ MonoBehaviour:
   enemyWaveInfos:
   - waveNumber: 1
     spawnStartDistance: 0
-    spawnInterval: 2
+    spawnInterval: 3
     spawnInfos:
     - enemyType: 0
       spawnProbabilityMin: 100
       spawnProbabilityMax: 100
   - waveNumber: 2
     spawnStartDistance: 40
-    spawnInterval: 2
+    spawnInterval: 2.2
     spawnInfos:
     - enemyType: 0
       spawnProbabilityMin: 75

--- a/Assets/ScriptableObjects/Enemy/Normal Enemy Config.asset
+++ b/Assets/ScriptableObjects/Enemy/Normal Enemy Config.asset
@@ -12,6 +12,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b24bba7e53d3ff49be9a9dcca0f92cc, type: 3}
   m_Name: Normal Enemy Config
   m_EditorClassIdentifier: Assembly-CSharp::NormalEnemyConfig
-  horizontalSpeed: 2
+  horizontalSpeed: 1.25
   hp: 1
   enemyType: 0

--- a/Assets/ScriptableObjects/GameConfig.asset
+++ b/Assets/ScriptableObjects/GameConfig.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::GameConfig
   playerSpeed: 3
   playerSpeedAcceleration: 1.5
-  distanceToGoal: 20
+  distanceToGoal: 135
   goalPrefab: {fileID: 1884644649632791674, guid: bf59f477d5e59c844b2e0cc14a78d256, type: 3}
   enemyDefeatBonusProgress: 0.01
   strongEnemyDefeatBonusProgress: 0.03

--- a/Assets/ScriptableObjects/Gauge/Bullet/BulletGaugeConfig.asset
+++ b/Assets/ScriptableObjects/Gauge/Bullet/BulletGaugeConfig.asset
@@ -13,5 +13,5 @@ MonoBehaviour:
   m_Name: BulletGaugeConfig
   m_EditorClassIdentifier: Assembly-CSharp::GaugeConfig
   max: 1
-  regenPerSec: 0.25
+  regenPerSec: 0.375
   regenDelayAfterUse: 0

--- a/Assets/ScriptableObjects/Gauge/Bullet/BulletGaugeCostConfig.asset
+++ b/Assets/ScriptableObjects/Gauge/Bullet/BulletGaugeCostConfig.asset
@@ -12,5 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 82db1e5daf2e28b40970554bf6d1dffb, type: 3}
   m_Name: BulletGaugeCostConfig
   m_EditorClassIdentifier: Assembly-CSharp::BulletCostConfig
-  normalBulletCost: 0.125
+  normalBulletCost: 0.3
   burstBulletCost: 1


### PR DESCRIPTION
UI部分の変更はHP画像の大きさ以外なし。
ゴールまでの距離地点を135　
各waveの切り替え時間を実施 waveに切り替わる時間の配分 
プレイヤー　ショットゲージの増加調整　
それに伴う通常ショットの 敵全員　あたり判定の調整 
Hopper 飛ぶ高さ↑ 移動速度↓ 調整 
強敵　→　HP10→6に変更