### PR TITLE
キャラの移動速度設定完了

### DIFF
--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -1629,7 +1629,7 @@ Transform:
   m_GameObject: {fileID: 1090739235}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.36, y: 0.484, z: 0}
+  m_LocalPosition: {x: 0.36, y: 3.5, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -2447,7 +2447,7 @@ BoxCollider2D:
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  m_Size: {x: 0.680287, y: 0.73099524}
+  m_Size: {x: 2, y: 9}
   m_EdgeRadius: 0
 --- !u!50 &1851829182
 Rigidbody2D:

--- a/Assets/ScriptableObjects/Enemy/Enemy Spawner Config.asset
+++ b/Assets/ScriptableObjects/Enemy/Enemy Spawner Config.asset
@@ -27,8 +27,11 @@ MonoBehaviour:
     - enemyType: 0
       spawnProbabilityMin: 100
       spawnProbabilityMax: 100
+    - enemyType: 0
+      spawnProbabilityMin: 100
+      spawnProbabilityMax: 100
   - waveNumber: 2
-    spawnStartDistance: 40
+    spawnStartDistance: 30
     spawnInterval: 2.2
     spawnInfos:
     - enemyType: 0
@@ -38,7 +41,7 @@ MonoBehaviour:
       spawnProbabilityMin: 45
       spawnProbabilityMax: 35
   - waveNumber: 3
-    spawnStartDistance: 70
+    spawnStartDistance: 60
     spawnInterval: 2
     spawnInfos:
     - enemyType: 0

--- a/Assets/ScriptableObjects/Enemy/Hopper Enemy Config.asset
+++ b/Assets/ScriptableObjects/Enemy/Hopper Enemy Config.asset
@@ -12,8 +12,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 858ce3cfc0390a34ba397b74133f4b21, type: 3}
   m_Name: Hopper Enemy Config
   m_EditorClassIdentifier: Assembly-CSharp::HopperEnemyConfig
-  horizontalSpeed: 2
+  horizontalSpeed: 0.45
   hp: 1
   enemyType: 1
-  verticalSpeed: 3
-  switchInterval: 0.5
+  verticalSpeed: 4
+  switchInterval: 0.56

--- a/Assets/ScriptableObjects/Enemy/Normal Enemy Config.asset
+++ b/Assets/ScriptableObjects/Enemy/Normal Enemy Config.asset
@@ -12,6 +12,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9b24bba7e53d3ff49be9a9dcca0f92cc, type: 3}
   m_Name: Normal Enemy Config
   m_EditorClassIdentifier: Assembly-CSharp::NormalEnemyConfig
-  horizontalSpeed: 1.25
+  horizontalSpeed: 1.1
   hp: 1
   enemyType: 0

--- a/Assets/ScriptableObjects/Enemy/Strong Enemy Config.asset
+++ b/Assets/ScriptableObjects/Enemy/Strong Enemy Config.asset
@@ -12,6 +12,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cbf5a6bce7fd6324fad7c50e0d7826fd, type: 3}
   m_Name: Strong Enemy Config
   m_EditorClassIdentifier: Assembly-CSharp::StrongEnemyConfig
-  horizontalSpeed: 2
+  horizontalSpeed: 1.5
   hp: 10
   enemyType: 2

--- a/Assets/ScriptableObjects/GameConfig.asset
+++ b/Assets/ScriptableObjects/GameConfig.asset
@@ -14,7 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Assembly-CSharp::GameConfig
   playerSpeed: 3
   playerSpeedAcceleration: 1.5
-  distanceToGoal: 135
+  distanceToGoal: 140
   goalPrefab: {fileID: 1884644649632791674, guid: bf59f477d5e59c844b2e0cc14a78d256, type: 3}
   enemyDefeatBonusProgress: 0.01
   strongEnemyDefeatBonusProgress: 0.03


### PR DESCRIPTION
waveの時間設定
Hopperの移動速度とジャンプ力
Hopperが当たらないプレイヤーのあたり判定があたるよう修正
ゴールまでの距離135→140に変更
強敵の移動速度を下方修正
通常的の移動速度を微下方修正

上げ忘れていたためプルリクを